### PR TITLE
LiquidFun / Phaser integration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ import logoImg from './assets/logo.png';
 import flipperImg from './assets/flipper.png';
 import ballImg from './assets/ball.png';
 
+import LiquidFunPhysics from './lf-phaser.js';
+
 
 var velocityIterations = 8;
 var positionIterations = 10;
@@ -32,6 +34,8 @@ class MyGame extends Phaser.Scene
 
         var gravity = new b2Vec2(0, 150);
         window.world = this.myWorld = new b2World(gravity);
+
+        this.physics = new LiquidFunPhysics(this.myWorld, { scale: 1, flip: false });
 
         var bd = new b2BodyDef();
         var ground = this.myWorld.CreateBody(bd);
@@ -101,26 +105,8 @@ class MyGame extends Phaser.Scene
     }
 
     update(dt) {
-        this.myWorld.Step(dt / 1000, velocityIterations, positionIterations);
-
-        // Adopted from liquidfun testbed: https://github.com/google/liquidfun/blob/master/liquidfun/Box2D/lfjs/testbed/renderer.js
-        for (var body of world.bodies) {
-            var transform = body.GetTransform();
-            for (var fixture of body.fixtures) {
-                if (fixture.shape.phaserSprite) {
-                    this.box2DUpdate(fixture.shape, transform);
-                }
-            }
-        }
-    }
-
-    box2DUpdate(shape, transform) {
-        var transformedPos = new b2Vec2();
-        var centroidPos = new b2Vec2();
-        b2Vec2.Add(centroidPos, shape.phaserCentroid || new b2Vec2(0, 0), shape.position)
-        b2Vec2.Mul(transformedPos, transform, centroidPos);
-        shape.phaserSprite.setPosition(transformedPos.x, transformedPos.y);
-        shape.phaserSprite.setAngle(180/ Math.PI * Math.atan2(transform.q.s, transform.q.c));
+        this.physics.update(dt);
+        console.log(this.flipperSprite.x)
     }
 }
 

--- a/src/lf-phaser.js
+++ b/src/lf-phaser.js
@@ -1,0 +1,87 @@
+var velocityIterations = 8;
+var positionIterations = 10;
+
+export default class LiquidFunPhysics {
+    constructor(
+        world,
+        {
+            scale = 10,
+            center = [0, 0],
+            flip = false
+        } = {}
+    ) {
+        this.world = world;
+        this.scale = scale;
+        this.center = center;
+        this.flip = flip ? -1 : 1;
+    }
+
+    update(dt) {
+        this.world.Step(dt / 1000, velocityIterations, positionIterations);
+
+        // World traversal adopted from liquidfun testbed:
+        // https://github.com/google/liquidfun/blob/master/liquidfun/Box2D/lfjs/testbed/renderer.js
+
+        for (var body of world.bodies) {
+            var transform = body.GetTransform();
+            for (var fixture of body.fixtures) {
+                this._updateSprite(fixture.shape, transform);
+            }
+        }
+
+        for (var system of world.particleSystems) {
+            for (var group of system.particleGroups) {
+                this._updateParticles(system, group);
+            }
+        }
+    }
+
+    _updateSprite(shape, transform) {
+        if (!shape.phaserSprite) {
+            return;
+        }
+
+        var transformedPos = new b2Vec2();
+        var centroidPos = new b2Vec2();
+        b2Vec2.Add(centroidPos, shape.phaserCentroid || new b2Vec2(0, 0), shape.position)
+        b2Vec2.Mul(transformedPos, transform, centroidPos);
+        shape.phaserSprite.setPosition(
+            this.center[0] + transformedPos.x * this.scale,
+            this.center[1] + transformedPos.y * this.scale * this.flip);
+        shape.phaserSprite.setAngle(this.flip * 180 / Math.PI * Math.atan2(transform.q.s, transform.q.c));
+    }
+
+    _updateParticles(system, group) {
+        const emitters = group.phaserParticleEmitters;
+        if (!emitters) {
+            return;
+        }
+
+        const particles = system.GetPositionBuffer();
+        const color = system.GetColorBuffer();
+        const offset = group.GetBufferIndex();
+        const count = group.GetParticleCount();
+
+        for (var emitter of emitters) {
+            emitter.setSpeed(0);
+            emitter.setLifespan(Infinity);
+            emitter.stop();
+            const xoffset = emitter.x.propertyValue;
+            const yoffset = emitter.y.propertyValue;
+
+            emitter.emitParticle(count - emitter.alive.length);  // ensure capacity
+
+            for (var i = 0; i < count; i++) {
+                const particle = emitter.alive[i];
+                particle.x = this.center[0] + particles[(i + offset) * 2] * this.scale + xoffset;
+                particle.y = this.center[1] + particles[(i + offset) * 2 + 1] * this.scale * this.flip + yoffset;
+
+                // To use LiquidFun's colors instead of Phaser's:
+                // particle.tint =
+                //       (color[(i + offset) * 4] << 16)
+                //     + (color[(i + offset) * 4 + 1] << 8)
+                //     + (color[(i + offset) * 4 + 2]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds support for Phaser rendering of Box2D shapes (as sprites) and LiquidFun particle systems.

To attach LiquidFun to a Phaser scene:

```
import LiquidFunPhysics from './lf-phaser.js’;

class MyScene extends Phaser.Scene {
    create() {
        ...
        this.physics = new LiquidFunPhysics(world);   // where world is your Box2D physics world
        ...
    }

    update(t, dt) {
        this.physics.update(dt);
        ...
    }
}
```

There are several options you can specify to translate from physics (Box2D) coordinates to screen (Phaser) coordinates:

```
this.physics = new LiquidFunPhysics(this.myWorld, {
    scale: 120,          // Factor for scaling up Box2D coordinates (in meters) to screen pixels
    center: [400, 400],  // Position of Box2D (0,0) in Phaser's scene
    flip: true           // Flip Y axis? (You can also negate gravity in your Box2D world instead)
});
```

You can attach a Phaser sprite to a Box2D shape:

```
        var circle = new b2CircleShape();
        circle.phaserSprite = this.add.image(0, 0, 'ball’);
        circle.phaserSprite.setScale(1.1);
```

The presence of the `phaserSprite` property causes the call to `physics.update()` to automatically position and reorient the sprite as the physics body moves. Note that nothing automatically matches the size of the sprite to the size of the body; it is up to you do determine the relationships between the size and shape of physics objects and how large they appear on the screen.

You can also render LiquidFun particle systems:

```
        const jello = this.add.particles('jello’);
        ...
        const group = particleSystem.CreateParticleGroup(pgd);
        group.phaserParticleEmitters = [
            jello.createEmitter({
                scale: 0.3
            })
        ];
```

This causes the Phaser particle emitter to create a group of particles that track the LiquidFun particles.

Note that the many [Particle emitter options](https://photonstorm.github.io/phaser3-docs/Phaser.Types.GameObjects.Particles.html#.ParticleEmitterConfig) that have to do with particle generation and motion have no effect once the emitter is attached to a LiquidFun particle system; LiquidFunPhysics entirely takes over particle creation and motion. However, _appearce_-related options such as `tint`, `blendMode`, and `alpha` do apply. LiquidFunPhysics also supports `x` and `y` options to apply a fixed offset to the rendered particles, which allows rendering effects if you attached multiple emitters to the same particle group.

Here is a complete usage example:

```js
import Phaser from 'phaser';

import logoImg from './assets/logo.png';
import flipperImg from './assets/flipper.png';
import ballImg from './assets/ball.png';
import jelloImg from './assets/jello.png';

import LiquidFunPhysics from './lf-phaser.js';

var shape = new b2EdgeShape;

class MyGame extends Phaser.Scene {
    constructor() {
        super();
    }

    preload() {
        this.load.image('ball', ballImg);
        this.load.image('jello', jelloImg);
        this.load.image('logo', logoImg);
        this.load.image('flipper',flipperImg);
    }
      
    create() {
        var gravity = new b2Vec2(0, -15);
        window.world = this.myWorld = new b2World(gravity);

        this.physics = new LiquidFunPhysics(this.myWorld, { scale: 120, center: [400, 400], flip: true });

        var bd = new b2BodyDef();
        var ground = world.CreateBody(bd);

        var shape1 = new b2PolygonShape();
        var vertices = shape1.vertices;
        vertices.push(new b2Vec2(-4, -1));
        vertices.push(new b2Vec2(4, -1));
        vertices.push(new b2Vec2(4, 0));
        vertices.push(new b2Vec2(-4, 0));
        ground.CreateFixtureFromShape(shape1, 0);

        var shape2 = new b2PolygonShape();
        var vertices = shape2.vertices;
        vertices.push(new b2Vec2(-4, -0.1));
        vertices.push(new b2Vec2(-2, -0.1));
        vertices.push(new b2Vec2(-2, 2));
        vertices.push(new b2Vec2(-4, 2));
        ground.CreateFixtureFromShape(shape2, 0);

        var shape3 = new b2PolygonShape();
        var vertices = shape3.vertices;
        vertices.push(new b2Vec2(2, -0.1));
        vertices.push(new b2Vec2(4, -0.1));
        vertices.push(new b2Vec2(4, 2));
        vertices.push(new b2Vec2(2, 2));
        ground.CreateFixtureFromShape(shape3, 0);

        var psd = new b2ParticleSystemDef();
        psd.radius = 0.035;
        var particleSystem = world.CreateParticleSystem(psd);

        const jello = this.add.particles('jello');

        // first group
        var box = new b2PolygonShape();
        box.SetAsBoxXY(0.5, 0.5);
        var pgd = new b2ParticleGroupDef();
        pgd.flags = b2_springParticle;
        pgd.groupFlags = b2_solidParticleGroup;
        pgd.shape = box;
        pgd.position.Set(0, 3);
        const group1 = particleSystem.CreateParticleGroup(pgd);
        group1.phaserParticleEmitters = [
            jello.createEmitter({
                tint: 0xFF0000,
                blendMode: Phaser.BlendModes.ADD,
                scale: 0.3,
            })
        ];

        // Alternative appearance: shiny highlights on top
        // (Code below replaces group1.phaserParticleEmitters above)

        // group1.phaserParticleEmitters = [
        //     jello.createEmitter({
        //         tint: 0xFF0000,
        //         scale: 0.4,
        //     }),
        //     jello.createEmitter({
        //         tint: 0x777777,
        //         blendMode: Phaser.BlendModes.ADD,
        //         scale: 0.3,
        //         y: -3
        //     }),
        //     jello.createEmitter({
        //         tint: 0xFF0000,
        //         scale: 0.3,
        //         y: 3
        //     })
        // ];

        // second group
        var box = new b2PolygonShape();
        box.SetAsBoxXY(0.4, 0.4);
        pgd = new b2ParticleGroupDef();
        pgd.flags = b2_elasticParticle;
        pgd.groupFlags = b2_solidParticleGroup;
        pgd.position.Set(-1, 3);
        pgd.shape = box;
        const group2 = particleSystem.CreateParticleGroup(pgd);
        group2.phaserParticleEmitters = [
            jello.createEmitter({
                tint: 0x00FF00,
                blendMode: Phaser.BlendModes.ADD,
                scale: 0.3,
            })
        ];

        // third group
        var box = new b2PolygonShape();
        box.SetAsBoxXY(1, 0.5);
        var pgd = new b2ParticleGroupDef();
        pgd.flags = b2_elasticParticle;
        pgd.groupFlags = b2_solidParticleGroup;
        pgd.position.Set(1, 4);
        pgd.angle = -0.5;
        pgd.angularVelocity = 2;
        pgd.shape = box;
        const group3 = particleSystem.CreateParticleGroup(pgd)
        group3.phaserParticleEmitters = [
            jello.createEmitter({
                tint: 0x0000FF,
                blendMode: Phaser.BlendModes.ADD,
                scale: 0.3,
            })
        ];

        // circle
        bd = new b2BodyDef();
        var circle = new b2CircleShape();
        circle.phaserSprite = this.add.image(0, 0, 'ball');
        circle.phaserSprite.setScale(1.1);
        bd.type = b2_dynamicBody;
        var body = world.CreateBody(bd);
        circle.position.Set(0, 8);
        circle.radius = 0.5;
        body.CreateFixtureFromShape(circle, 0.5);
    }

    update(t, dt) {
        this.physics.update(dt);
    }
}

const config = {
    type: Phaser.AUTO,
    parent: 'phaser-example',
    width: 800,
    height: 600,
    backgroundColor: '#002266',
    scene: MyGame
};

const game = new Phaser.Game(config);
```